### PR TITLE
Update conf.py

### DIFF
--- a/src/pvlab/doc/source/conf.py
+++ b/src/pvlab/doc/source/conf.py
@@ -15,6 +15,9 @@ https://www.sphinx-doc.org/en/master/usage/configuration.html
 #
 import os
 import sys
+import pvlab
+
+
 sys.path.insert(0, os.path.abspath('.'))
 sys.path.insert(1, os.path.abspath('..'))
 sys.path.insert(2, os.path.abspath(os.path.join('..',


### PR DESCRIPTION
'import pvlab' has been added to src/doc/source/conf.py.
Try to add 'pvlab' so that sphinx can read docstrings of modules and their functions through ".. automodule::" directives in sub-packages "dataframes" and "math". So far, ".. automodule::" directives in .rst files "tools_dataframes.rst" and "tools_math.rst" seem not being working fine.
